### PR TITLE
Updated .env generation to wrap DOCKER_SHARED_VOLUME env var in quotes

### DIFF
--- a/generate_tim.sh
+++ b/generate_tim.sh
@@ -41,7 +41,7 @@ setupEnv() {
       echo "DOCKER_HOST_IP=$DOCKER_HOST_IP" > .env
 
       # write DOCKER_SHARED_VOLUME to .env
-      echo "DOCKER_SHARED_VOLUME=$PWD/shared" >> .env
+      echo "DOCKER_SHARED_VOLUME=\"$PWD/shared\"" >> .env
   elif [ -f .env ]; then
     echo "Identified existing .env file..."
   fi

--- a/start_ode.sh
+++ b/start_ode.sh
@@ -42,7 +42,7 @@ setupEnv() {
       echo "DOCKER_HOST_IP=$DOCKER_HOST_IP" > .env
 
       # write DOCKER_SHARED_VOLUME to .env
-      echo "DOCKER_SHARED_VOLUME=$PWD/shared" >> .env
+      echo "DOCKER_SHARED_VOLUME=\"$PWD/shared\"" >> .env
   elif [ -f .env ]; then
     echo "Identified existing .env file..."
   fi


### PR DESCRIPTION
## Problem
Some users may use spaces in the DOCKER_SHARED_VOLUME path which require quotes to be processed correctly.

## Solution
The value for the DOCKER_SHARED_VOLUME environment variable is now wrapped in quotes upon .env file generation.

## Testing
Tested locally using WSL