### PR TITLE
Fix Docker Host IP Retrieval by Targeting eth0 Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ Run the following command to stop the ODE:
 ```bash
 docker compose down
 ```
+
+## Note on eth0
+In order to run the ODE in Docker, the `DOCKER_HOST_IP` environment variable must be set to the IP address of the machine running Docker. The provided scripts use the `retrieve_docker_host_ip.sh` script to retrieve the IP address of the machine running Docker. The `retrieve_docker_host_ip.sh` script targets the `eth0` interface to retrieve the IP address. If your machine uses a different interface, you will need to update the script to target the correct interface.

--- a/generate_tim.sh
+++ b/generate_tim.sh
@@ -29,7 +29,12 @@ setupEnv() {
     if [ -z $DOCKER_HOST_IP ]
       then
           ensureNetTools
-          export DOCKER_HOST_IP=$(ifconfig | grep -A 1 'inet ' | grep -v 'inet6\|127.0.0.1' | awk '{print $2}' | grep -E '^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.' | head -n 1)
+          # call retrieve_docker_host_ip.sh to get DOCKER_HOST_IP
+          . retrieve_docker_host_ip.sh
+          if [ $? -ne 0 ]; then
+              echo "Failed to retrieve DOCKER_HOST_IP. Exiting."
+              exit 1
+          fi
       fi
       if [ -z $DOCKER_HOST_IP ]
       then

--- a/retrieve_docker_host_ip.sh
+++ b/retrieve_docker_host_ip.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script is used to retrieve the IP address of the host machine that is running the docker containers. The `eth0` interface is used to determine the IP address.
+
+ip_output=$(ifconfig eth0 2>/dev/null)
+if [ -z "$ip_output" ]; then
+    echo "Error: Network interface eth0 not found."
+    exit 1
+fi
+
+inet_line=$(echo "$ip_output" | grep 'inet ' | grep -v 'inet6\|127.0.0.1')
+if [ -z "$inet_line" ]; then
+    echo "Error: No valid inet line found."
+    exit 1
+fi
+
+ip_address=$(echo "$inet_line" | awk '{print $2}')
+valid_ip=$(echo "$ip_address" | grep -E '^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.')
+if [ -z "$valid_ip" ]; then
+    echo "Error: No valid IP address found."
+    exit 1
+fi
+
+export DOCKER_HOST_IP=$(echo "$valid_ip" | head -n 1)

--- a/start_ode.sh
+++ b/start_ode.sh
@@ -30,7 +30,12 @@ setupEnv() {
     if [ -z $DOCKER_HOST_IP ]
       then
           ensureNetTools
-          export DOCKER_HOST_IP=$(ifconfig | grep -A 1 'inet ' | grep -v 'inet6\|127.0.0.1' | awk '{print $2}' | grep -E '^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.' | head -n 1)
+          # call retrieve_docker_host_ip.sh to get DOCKER_HOST_IP
+          . retrieve_docker_host_ip.sh
+          if [ $? -ne 0 ]; then
+              echo "Failed to retrieve DOCKER_HOST_IP. Exiting."
+              exit 1
+          fi
       fi
       if [ -z $DOCKER_HOST_IP ]
       then


### PR DESCRIPTION
## Problem
When retrieving the Docker host IP, the incorrect network interface may be targeted, leading to a non-functional ODE deployment.

## Solution
A new script has been introduced to specifically target the eth0 interface when retrieving the Docker host IP. This script is used by both start_ode.sh and generate_tim.sh if a .env file is missing and needs to be generated.

## Testing
This was tested locally using WSL.