### PR TITLE
Update Test Data Lat/Lon Offsets to Comply with J2735 Specification

### DIFF
--- a/data/tim.json
+++ b/data/tim.json
@@ -67,62 +67,62 @@
               "nodes": [
                 {
                   "nodeLong": "0.0002047",
-                  "nodeLat": "-0.0002048",
+                  "nodeLat": "-0.0002047",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0008191",
-                  "nodeLat": "-0.0008192",
+                  "nodeLat": "-0.0008191",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0032767",
-                  "nodeLat": "-0.0032768",
+                  "nodeLat": "-0.0032767",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0131071",
-                  "nodeLat": "-0.0131072",
+                  "nodeLat": "-0.0131071",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.2097151",
-                  "nodeLat": "-0.2097152",
+                  "nodeLat": "-0.2097151",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.8388607",
-                  "nodeLat": "-0.8388608",
+                  "nodeLat": "-0.8388607",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0002047",
-                  "nodeLat": "-0.0002048",
+                  "nodeLat": "-0.0002047",
                   "delta": "node-LL1"
                 },
                 {
                   "nodeLong": "0.0008191",
-                  "nodeLat": "-0.0008192",
+                  "nodeLat": "-0.0008191",
                   "delta": "node-LL2"
                 },
                 {
                   "nodeLong": "0.0032767",
-                  "nodeLat": "-0.0032768",
+                  "nodeLat": "-0.0032767",
                   "delta": "node-LL3"
                 },
                 {
                   "nodeLong": "0.0131071",
-                  "nodeLat": "-0.0131072",
+                  "nodeLat": "-0.0131071",
                   "delta": "node-LL4"
                 },
                 {
                   "nodeLong": "0.2097151",
-                  "nodeLat": "-0.2097152",
+                  "nodeLat": "-0.2097151",
                   "delta": "node-LL5"
                 },
                 {
                   "nodeLong": "0.8388607",
-                  "nodeLat": "-0.8388608",
+                  "nodeLat": "-0.8388607",
                   "delta": "node-LL6"
                 },
                 {

--- a/data/tim_sdx.json
+++ b/data/tim_sdx.json
@@ -60,62 +60,62 @@
               "nodes": [
                 {
                   "nodeLong": "0.0002047",
-                  "nodeLat": "-0.0002048",
+                  "nodeLat": "-0.0002047",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0008191",
-                  "nodeLat": "-0.0008192",
+                  "nodeLat": "-0.0008191",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0032767",
-                  "nodeLat": "-0.0032768",
+                  "nodeLat": "-0.0032767",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0131071",
-                  "nodeLat": "-0.0131072",
+                  "nodeLat": "-0.0131071",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.2097151",
-                  "nodeLat": "-0.2097152",
+                  "nodeLat": "-0.2097151",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.8388607",
-                  "nodeLat": "-0.8388608",
+                  "nodeLat": "-0.8388607",
                   "delta": "node-LL"
                 },
                 {
                   "nodeLong": "0.0002047",
-                  "nodeLat": "-0.0002048",
+                  "nodeLat": "-0.0002047",
                   "delta": "node-LL1"
                 },
                 {
                   "nodeLong": "0.0008191",
-                  "nodeLat": "-0.0008192",
+                  "nodeLat": "-0.0008191",
                   "delta": "node-LL2"
                 },
                 {
                   "nodeLong": "0.0032767",
-                  "nodeLat": "-0.0032768",
+                  "nodeLat": "-0.0032767",
                   "delta": "node-LL3"
                 },
                 {
                   "nodeLong": "0.0131071",
-                  "nodeLat": "-0.0131072",
+                  "nodeLat": "-0.0131071",
                   "delta": "node-LL4"
                 },
                 {
                   "nodeLong": "0.2097151",
-                  "nodeLat": "-0.2097152",
+                  "nodeLat": "-0.2097151",
                   "delta": "node-LL5"
                 },
                 {
                   "nodeLong": "0.8388607",
-                  "nodeLat": "-0.8388608",
+                  "nodeLat": "-0.8388607",
                   "delta": "node-LL6"
                 },
                 {


### PR DESCRIPTION
## Problem  
The J2735 specification states that the smallest number in the INTEGER range for latitude/longitude offsets represents an unknown value and should not be used.  

## Solution  
The latitude/longitude offsets in the data files have been adjusted to comply with the constraints defined in the J2735 specification.  

## Testing  
The `./generate-tim.sh` script was executed using the branch [fix/node-ll-selection](https://github.com/Trihydro/jpo-ode/tree/fix/node-ll-selection), and it was confirmed that the `InvalidNodeLatLonOffsetException` was not thrown.  

### Note  
Changes to the ODE logging level configurations require modifications to the `./generate-tim.sh` script for UPER file generation. However, these adjustments are beyond the scope of this update, as the `docker-compose.yml` file needs to be updated separately (opened https://github.com/Trihydro/Interop-ODE/issues/15 for this).