### PR TITLE
fix: strip '1:' from retrieved log message

### DIFF
--- a/generate_tim.sh
+++ b/generate_tim.sh
@@ -106,7 +106,7 @@ grabLatestLine() {
 
 extractHexValue() {
     # extract HEX value from the line
-    hex_value=$(echo $latest_line | grep -oP '(?<=Encoded message - phase ).*')
+    hex_value=$(echo $latest_line | grep -oP '(?<=Encoded message - phase 1:).*')
     if [ -z "$hex_value" ]; then
         echo "Failed to extract HEX value from the line. Please try again."
         exit 1


### PR DESCRIPTION
## Problem
The string "1:" was showing up in the generated `.uper` file.

## Solution
The `generate_tim.sh` file has been updated to strip "1:" from the retrieved log message.

## Testing
Tested locally by spinning up ODE with `./start_ode.sh` and generating TIM with `./generate_tim.sh`.